### PR TITLE
chore: rename module to match repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Go queue worker - A Golang Library for Efficient Queue Processing.
+# Formigo - A Golang Library for Efficient Queue Processing.
 
-Go queue worker is a powerful and flexible Golang library designed to simplify the processing of messages from queues. It currently supports AWS SQS, with the capability to extend its functionality to accommodate multiple types of queues. With this library, you can effortlessly manage and scale the concurrent processing of messages, ensuring efficient utilization of resources and increased throughput.
+Formigo is a powerful and flexible Golang library designed to simplify the processing of messages from queues. It currently supports AWS SQS, with the capability to extend its functionality to accommodate multiple types of queues. With this library, you can effortlessly manage and scale the concurrent processing of messages, ensuring efficient utilization of resources and increased throughput.
 
 ## Key Features
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Make sure you have Go installed [download](https://go.dev/dl/)
 Initialize your project by creating a folder and then running `go mod init github.com/your/repo` inside the folder. Then install the library with the [`go get`](https://pkg.go.dev/cmd/go/#hdr-Add_dependencies_to_current_module_and_install_them) command:
 
 ```bash
-go get -u github.com/francescopepe/go-queue-worker
+go get -u github.com/francescopepe/formigo
 ```
 
 ## Examples
@@ -38,8 +38,8 @@ import (
     "fmt"
     "log"
 
-    "github.com/francescopepe/go-queue-worker"
-    workerSqs "github.com/francescopepe/go-queue-worker/clients/sqs"
+    "github.com/francescopepe/formigo"
+    workerSqs "github.com/francescopepe/formigo/clients/sqs"
 
     "github.com/aws/aws-sdk-go-v2/aws"
     "github.com/aws/aws-sdk-go-v2/config"
@@ -104,8 +104,8 @@ import (
     "fmt"
     "log"
 
-    "github.com/francescopepe/go-queue-worker"
-    workerSqs "github.com/francescopepe/go-queue-worker/clients/sqs"
+    "github.com/francescopepe/formigo"
+    workerSqs "github.com/francescopepe/formigo/clients/sqs"
 
     "github.com/aws/aws-sdk-go-v2/aws"
     "github.com/aws/aws-sdk-go-v2/config"

--- a/clients/sqs/sqs.go
+++ b/clients/sqs/sqs.go
@@ -8,8 +8,8 @@ import (
 	awsSqs "github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
 
-	"github.com/francescopepe/go-queue-worker/internal/client"
-	"github.com/francescopepe/go-queue-worker/internal/messages"
+	"github.com/francescopepe/formigo/internal/client"
+	"github.com/francescopepe/formigo/internal/messages"
 )
 
 type SqsClientConfiguration struct {

--- a/config.go
+++ b/config.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/francescopepe/go-queue-worker/internal/client"
+	"github.com/francescopepe/formigo/internal/client"
 )
 
 const (

--- a/consumers.go
+++ b/consumers.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/francescopepe/go-queue-worker/internal/messages"
+	"github.com/francescopepe/formigo/internal/messages"
 )
 
 type singleMessageHandler = func(ctx context.Context, msg interface{}) error

--- a/deleter.go
+++ b/deleter.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/francescopepe/go-queue-worker/internal/client"
-	"github.com/francescopepe/go-queue-worker/internal/messages"
+	"github.com/francescopepe/formigo/internal/client"
+	"github.com/francescopepe/formigo/internal/messages"
 )
 
 // deleter will delete messages from SQS until the delete channel gets closed.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/francescopepe/go-queue-worker
+module github.com/francescopepe/formigo
 
 go 1.20
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/francescopepe/go-queue-worker/internal/messages"
+import "github.com/francescopepe/formigo/internal/messages"
 
 type MessageReceiver interface {
 	ReceiveMessages() ([]messages.Message, error)

--- a/retriever.go
+++ b/retriever.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 
-	"github.com/francescopepe/go-queue-worker/internal/client"
-	"github.com/francescopepe/go-queue-worker/internal/messages"
+	"github.com/francescopepe/formigo/internal/client"
+	"github.com/francescopepe/formigo/internal/messages"
 )
 
 // retriever will get messages from SQS until the given context gets canceled.

--- a/worker.go
+++ b/worker.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/francescopepe/go-queue-worker/internal/client"
-	"github.com/francescopepe/go-queue-worker/internal/messages"
+	"github.com/francescopepe/formigo/internal/client"
+	"github.com/francescopepe/formigo/internal/messages"
 )
 
 type worker struct {


### PR DESCRIPTION
This PR renames the module name in `go.mod` to match the new repository name