### PR TITLE
chore: retract v1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,3 +16,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+retract v1.0.0 // Accidentally added


### PR DESCRIPTION
Retract `v1.0.0` as it was accidentally published