### PR TITLE
Retraction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,4 +17,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-retract v1.0.0 // Accidentally added
+retract (
+	v1.0.0 // Accidentally added
+	v1.0.1 // Contains retractions only.
+)


### PR DESCRIPTION
Hi Fra! 👋 

I did a `go work sync` earlier and it decided to update everything to formigo v1.0.0 which it looks like was published accidentally. I know you've put a retraction in the `go.mod` file, but according to the [go docs](https://go.dev/ref/mod#go-mod-file-retract) you'll need to publish a version above the accidentally published version with the retraction.

I've added a retraction for `v1.0.1` to the `go.mod` and if you publish a `v1.0.1` then it should stop any other issues like this 🤞 